### PR TITLE
Stick repo names from the webook into the SQS queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ To run project in development mode clone the project and do:
 
     python setup.py develop
 
+The following environment variables must be set to the appropriate values:
+  * `GITHUB_WEBHOOK_SECRET`
+  * `AWS_DEFAULT_REGION`
+  * `AWS_ACCESS_KEY_ID`
+  * `AWS_SECRET_ACCESS_KEY`
+
 ## Testing
 
 To run project tests do:

--- a/bin/webhook_server
+++ b/bin/webhook_server
@@ -85,15 +85,15 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     self.end_headers()
 
 if __name__ == '__main__':
-    arguments = docopt(__doc__, version=__version__)
+  arguments = docopt(__doc__, version=__version__)
 
-    logger = setup_logging(arguments)
+  logger = setup_logging(arguments)
 
-    port = int(arguments.get('<port>', '80'))
+  port = int(arguments.get('<port>', '80'))
 
-    server = BaseHTTPServer.HTTPServer(('0.0.0.0', port), RequestHandler)
-    try:
-      server.serve_forever()
-    except KeyboardInterrupt:
-      pass
-    server.server_close()
+  server = BaseHTTPServer.HTTPServer(('0.0.0.0', port), RequestHandler)
+  try:
+    server.serve_forever()
+  except KeyboardInterrupt:
+    pass
+  server.server_close()

--- a/bin/webhook_server
+++ b/bin/webhook_server
@@ -11,15 +11,16 @@ Options:
     -v --logging (debug | info | error)
 """
 
-import logging
 import BaseHTTPServer
-from docopt import docopt
-import json
-import hmac
 import hashlib
+import hmac
+import json
+import logging
 import os
 
-from gitenberg.autoupdate import __version__
+from docopt import docopt
+
+from gitenberg.autoupdate import __version__, queue
 
 
 FORMAT = '%(asctime)-15s %(message)s'
@@ -76,7 +77,9 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     except ValueError:
       self.send_error(400)
       return
-    print('Payload is %s' % repr(payload))
+
+    repo = payload[u'repository'][u'full_name']
+    queue.queue_resource().send_message(MessageBody=repo)
 
     self.send_response(200)
     self.end_headers()

--- a/bin/webhook_server
+++ b/bin/webhook_server
@@ -15,6 +15,9 @@ import logging
 import BaseHTTPServer
 from docopt import docopt
 import json
+import hmac
+import hashlib
+import os
 
 from gitenberg.autoupdate import __version__
 
@@ -43,16 +46,31 @@ def setup_logging(arguments):
 
     return logger
 
+GITHUB_WEBHOOK_SECRET = os.environ['GITHUB_WEBHOOK_SECRET']
+
+def _verify_signature(body, signature):
+  signature_check = 'sha1=' + hmac.new(GITHUB_WEBHOOK_SECRET, body, hashlib.sha1).hexdigest()
+  return not hmac.compare_digest(signature, signature_check)
+
 class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
   def do_POST(self):
     if self.path != '/payload':
       self.send_error(404)
       return
 
-    # TODO(Brian): https://developer.github.com/webhooks/securing/
+    if 'Content-Length' not in self.headers:
+      self.send_error(400)
+      return
+    if 'X-Hub-Signature' not in self.headers:
+      self.send_error(400)
+      return
 
     content_length = int(self.headers['Content-Length'])
     payload_string = self.rfile.read(content_length)
+    if _verify_signature(payload_string, self.headers['X-Hub-Signature']):
+      self.send_error(500)
+      return
+
     try:
       payload = json.loads(payload_string)
     except ValueError:

--- a/gitenberg/autoupdate/queue.py
+++ b/gitenberg/autoupdate/queue.py
@@ -1,0 +1,14 @@
+import boto3
+
+_sqs_queue = None
+def queue_resource():
+  """Returns the SQS queue to use for queuing book updates.
+
+  This is lazily created when first being called."""
+
+  global _sqs_queue
+  if _sqs_queue is None:
+    _sqs_queue = boto3.resource('sqs').get_queue_by_name(
+        QueueName='gitberg-autoupdate-repositories',
+        )
+  return _sqs_queue

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name='gitberg',
           'docopt>=0.6',
           'six==1.10.0',
           'PyYAML==3.11',
+          'boto3',
       ],
       test_suite='nose.collector',
       tests_require=[


### PR DESCRIPTION
webhook_server now puts the repository names from hook calls into an SQS queue. This should mean webhook_server is finished except for SSL support and packaging.