### PR TITLE
Add a skeleton of a worker to handle messages from the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Both servers run in an AWS Elastic Beanstalk (EBS) application. `webhook_server`
 runs as a "Web server environment", and `autoupdate_worker` runs as a
 "Worker environment".
 
-Configure the following environment variables (under Configuration > Software > Environment properties):
+Configure the following environment variables (under Configuration > Software > Environment properties) for `webhook_server` environments:
   * `GITHUB_WEBHOOK_SECRET`
   * `AWS_DEFAULT_REGION`
   * Note that you *must* set these *all* when first creating the environment.
@@ -43,11 +43,21 @@ Configure the following environment variables (under Configuration > Software > 
   * Don't set `AWS_ACCESS_KEY_ID` or `AWS_SECRET_ACCESS_KEY`. The EBS instance
     role will be picked up automatically instead.
 
-The EBS environment must be configured as follows:
+The EBS environment must be configured as follows for `webhook_server` environments:
   * Virtual machine instance profile: elasticbeanstalk-ec2-autoupdate
-  * Health check path (under Monitoring): /health
+  * Health check path (under Monitoring): `/health`
   * Environment type: load balancing
   * Load balancer: add a HTTPS listener on 443 which delivers to HTTP on 80, using an appropriate SSL certificate
+
+Configure the following environment variables (under Configuration > Software > Environment properties) for `autoupdate_worker` environments:
+  * `GITENBERG_SECRET`
+
+The EBS environment must be configured as follows for `autoupdate_worker` environments:
+  * Virtual machine instance profile: elasticbeanstalk-ec2-autoupdate
+  * Health check path (under Monitoring): `/health`
+  * Environment type: load balancing
+  * HTTP path (under Worker): `/do_update`
+  * Worker queue (under Worker): gitberg-autoupdate-repositories
 
 ### Local mock deployment
 
@@ -55,7 +65,7 @@ To run one of the servers locally in a Docker container identical to the one
 which will be used by EBS, use these commands:
 ```console
 $ docker build -f deploy/webhook_server/Dockerfile -t webhook_server ./ && docker run -i --env-file test_env -p 127.0.0.1:1234:80 webhook_server
-$ docker build -f deploy/autoupdate_worker/Dockerfile -t autoupdate_worker ./ && docker run -i --env-file test_env autoupdate_worker
+$ docker build -f deploy/autoupdate_worker/Dockerfile -t autoupdate_worker ./ && docker run -i --env-file test_env -p 127.0.0.1:1235:80 autoupdate_worker
 ```
 
 These commands rely on a file called `test_env` with the environment variables

--- a/bin/autoupdate_worker
+++ b/bin/autoupdate_worker
@@ -2,34 +2,64 @@
 # -*- coding: utf-8 -*-
 """
 Usage:
-    autoupdate_worker [options]
+    autoupdate_worker --port <port> [options]
 
 Arguments:
+    <port> -- The port to run the server on.
 
 Options:
     --logging (debug | info | error)
     --log_file <log_file> also log to a file
 """
 
+import BaseHTTPServer
 import logging
 
 from docopt import docopt
 
 from gitenberg.autoupdate import __version__, queue, util
 
-def process_queue_entries():
-  while True:
-    for message in queue.queue_resource().receive_messages(
-        MaxNumberOfMessages=3, WaitTimeSeconds=20):
-      # TODO(Marc): Process the repository, and only take the below if
-      # statement if it succeeds.
-      logging.info('Got a message for %s' % message.body)
-      if True:
-        message.delete()
+class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+  def do_GET(self):
+    if self.path != '/health':
+      self.send_error(404)
+      return
+
+    # Claim we're alive and healthy if we're responding to this GET.
+    self.send_response(200)
+    self.end_headers()
+
+  def do_POST(self):
+    if self.path != '/do_update':
+      self.send_error(404)
+      return
+
+    if 'Content-Length' not in self.headers:
+      self.send_error(400)
+      return
+
+    content_length = int(self.headers['Content-Length'])
+    payload_string = self.rfile.read(content_length)
+    logging.info('Got a message for %s' % payload_string)
+    # TODO(Marc): Process the repository, and take the below if
+    # statement if it fails.
+    if False:
+      self.send_error(500)
+      return
+
+    self.send_response(200)
+    self.end_headers()
 
 if __name__ == '__main__':
   arguments = docopt(__doc__, version=__version__)
 
   util.setup_logging(arguments)
 
-  process_queue_entries()
+  port = int(arguments.get('<port>', '80'))
+
+  server = BaseHTTPServer.HTTPServer(('0.0.0.0', port), RequestHandler)
+  try:
+    server.serve_forever()
+  except KeyboardInterrupt:
+    pass
+  server.server_close()

--- a/bin/autoupdate_worker
+++ b/bin/autoupdate_worker
@@ -13,11 +13,61 @@ Options:
 """
 
 import BaseHTTPServer
+import errno
 import logging
+import os.path
+import shutil
+import tarfile
+import time
 
 from docopt import docopt
+import requests
 
 from gitenberg.autoupdate import __version__, queue, util
+
+RDF_URL = "https://www.gutenberg.org/cache/epub/feeds/rdf-files.tar.bz2"
+RDF_PATH = "/tmp/rdf.tar.bz2"
+RDF_EXTRACT_PATH = "/tmp/extracted_rdf"
+# 1 day
+RDF_MAX_AGE = 60 * 60 * 24
+
+def download_rdf():
+  """Ensures a fresh-enough RDF file is downloaded and extracted.
+
+  Returns True on error."""
+
+  if (os.path.exists(RDF_PATH) and
+      (time.time() - os.path.getmtime(RDF_PATH)) < RDF_MAX_AGE):
+    return False
+
+  logging.info('Re-downloading RDF library from %s' % RDF_URL)
+  try:
+    shutil.rmtree(RDF_EXTRACT_PATH)
+  except OSError as e:
+    # Ignore not finding the directory to remove.
+    if e.errno != errno.ENOENT:
+      raise
+
+  try:
+    with open(RDF_PATH, 'w') as f:
+      with requests.get(RDF_URL, stream=True) as r:
+        shutil.copyfileobj(r.raw, f)
+  except requests.exceptions.RequestException as e:
+    logging.error(e)
+    return True
+
+  try:
+    with tarfile.open(RDF_PATH, 'r') as f:
+      f.extractall(RDF_EXTRACT_PATH)
+  except tarfile.TarError as e:
+    logging.error(e)
+    try:
+      os.unlink(RDF_PATH)
+    except:
+      pass
+    return True
+
+  return False
 
 class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
   def do_GET(self):
@@ -36,6 +86,10 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
     if 'Content-Length' not in self.headers:
       self.send_error(400)
+      return
+
+    if download_rdf():
+      self.send_error(500)
       return
 
     content_length = int(self.headers['Content-Length'])

--- a/deploy/autoupdate_worker/Dockerfile
+++ b/deploy/autoupdate_worker/Dockerfile
@@ -2,7 +2,12 @@ FROM python:2
 
 EXPOSE 80
 
-RUN apt-get update && apt-get -y install cron logrotate && apt-get clean
+RUN apt-get update && apt-get -y install cron logrotate ruby xsltproc xvfb calibre git libjpeg-dev libpng-dev libfreetype6-dev zlib1g-dev libxml2-dev libxslt1-dev tidy && apt-get clean
+RUN gem install tilt
+RUN pip install git+https://github.com/gitenberg-dev/pg-epubmaker git+https://github.com/gitenberg-dev/gitberg-build
+RUN gem install asciidoctor -v 1.5.2
+
+RUN git clone https://github.com/gitenberg-dev/asciidoctor-htmlbook.git && pip install -r asciidoctor-htmlbook/gitberg-machine/requirements.txt && rm -r asciidoctor-htmlbook
 
 RUN mkdir /var/log/gitenberg
 COPY deploy/logrotate-gitberg-autoupdate /etc/logrotate.d/

--- a/deploy/autoupdate_worker/Dockerfile
+++ b/deploy/autoupdate_worker/Dockerfile
@@ -12,4 +12,4 @@ WORKDIR /usr/src/app
 COPY . .
 RUN python ./setup.py install
 
-CMD service cron start && exec autoupdate_worker --log_file /var/log/gitenberg/autoupdate_worker
+CMD service cron start && exec autoupdate_worker --port 80 --log_file /var/log/gitenberg/autoupdate_worker


### PR DESCRIPTION
It currently just logs what repository they're from and then always
returns success so EBS will pull them out of the queue

This is deployed and successfully logging repository names.