### PR TITLE
Ignore webhooks for unknown repos or events

### DIFF
--- a/bin/webhook_server
+++ b/bin/webhook_server
@@ -20,6 +20,7 @@ import logging
 import os
 
 from docopt import docopt
+from gitenberg.util import catalog
 
 from gitenberg_autoupdate import __version__, queue, util
 
@@ -32,6 +33,7 @@ def _verify_signature(body, signature):
 class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
   def do_GET(self):
     if self.path != '/health':
+      logging.info('Unknown GET endpoint %s' % self.path)
       self.send_error(404)
       return
 
@@ -41,31 +43,62 @@ class RequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
 
   def do_POST(self):
     if self.path != '/payload':
+      logging.info('Unknown POST endpoint %s' % self.path)
       self.send_error(404)
       return
 
     if 'Content-Length' not in self.headers:
+      logging.info('No Content-Length')
       self.send_error(400)
       return
     if 'X-Hub-Signature' not in self.headers:
+      logging.info('No signature')
+      self.send_error(400)
+      return
+    if 'X-GitHub-Event' not in self.headers:
+      logging.info('No event')
       self.send_error(400)
       return
 
     content_length = int(self.headers['Content-Length'])
     payload_string = self.rfile.read(content_length)
     if _verify_signature(payload_string, self.headers['X-Hub-Signature']):
+      logging.info('Error validating signature')
       self.send_error(500)
+      return
+
+    if self.headers['X-GitHub-Event'] != 'push':
+      # Just ignore all other hook types.
+      logging.info('Unknown event %s' % self.headers['X-GitHub-Event'])
+      self.send_response(200)
+      self.end_headers()
       return
 
     try:
       payload = json.loads(payload_string)
     except ValueError:
+      logging.info('Error parsing JSON')
+      self.send_error(400)
+      return
+
+    if u'repository' not in payload:
+      logging.info('No repository in %s' % json.dumps(payload_string))
+      self.send_error(400)
+      return
+    if u'full_name' not in payload[u'repository']:
+      logging.info('No full_name in %s' % json.dumps(payload[u'repository']))
       self.send_error(400)
       return
 
     repo = payload[u'repository'][u'full_name']
-    logging.info('Sending message for %s' % repo)
+    if repo not in catalog.get_all_repo_names():
+      logging.info('Unknown repo %s' % repo)
+      self.send_response(200)
+      self.end_headers()
+      return
+
     queue.queue_resource().send_message(MessageBody=repo)
+    logging.info('Sent message for %s' % repo)
 
     self.send_response(200)
     self.end_headers()

--- a/deploy/autoupdate_worker/Dockerfile
+++ b/deploy/autoupdate_worker/Dockerfile
@@ -15,8 +15,8 @@ COPY deploy/logrotate-gitberg-autoupdate /etc/logrotate.d/
 WORKDIR /usr/src/app
 
 # This is slow, so avoid having to do it every time.
-RUN pip install boto3
+RUN pip install boto3 travispy
 COPY . .
-RUN pip install .
+RUN pip install . --process-dependency-links
 
 CMD service cron start && exec autoupdate_worker --port 80 --log_file /var/log/gitenberg/autoupdate_worker

--- a/deploy/webhook_server/Dockerfile
+++ b/deploy/webhook_server/Dockerfile
@@ -10,8 +10,8 @@ COPY deploy/logrotate-gitberg-autoupdate /etc/logrotate.d/
 WORKDIR /usr/src/app
 
 # This is slow, so avoid having to do it every time.
-RUN pip install boto3
+RUN pip install boto3 travispy
 COPY . .
-RUN pip install .
+RUN pip install . --process-dependency-links
 
 CMD service cron start && exec webhook_server --port 80 --log_file /var/log/gitenberg/webhook_server

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='gitberg.autoupdate',
           'six==1.10.0',
           'PyYAML==3.11',
           'boto3',
-          'gitberg',
+          'gitberg==dev',
       ],
       test_suite='nose.collector',
       tests_require=[
@@ -50,6 +50,6 @@ setup(name='gitberg.autoupdate',
       ],
       keywords="books ebooks gitenberg gutenberg epub metadata",
       dependency_links=[
-          "https://github.com/gitenberg-dev/gitberg/archive/676709fd1ffd425ca81161b0e99236c30fe667f8.zip#egg=gitberg-0.3.1",
+          "https://github.com/gitenberg-dev/gitberg/archive/50fa39caeaa89e32031ca0eef21091bb798739fc.zip#egg=gitberg-dev",
       ],
       )


### PR DESCRIPTION
This makes it respond usefully to GitHub's ping event. I also recently
learned that there are non-book repos in the GITenberg organization, so
ignore those.